### PR TITLE
Fix: don't warn with bare imports

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -216,6 +216,19 @@ describe("unmatched import/export style and cache", () => {
     })
   );
   
+  it("don't warn with bare import (name)", () =>
+    withDir(`
+      - entry.js: |
+          import "./foo.js";
+      - foo.js: |
+          exports.foo = "foo";
+    `, async resolve => {
+      let warns;
+      ({warns} = await bundle(resolve("entry.js"), {cache: resolve(".cjsescache")}));
+      assert.equal(warns.length, 0);
+    })
+  );
+  
   it("import default if others import default", () =>
     withDir(`
       - entry.js: |

--- a/test/test.js
+++ b/test/test.js
@@ -216,10 +216,23 @@ describe("unmatched import/export style and cache", () => {
     })
   );
   
-  it("don't warn with bare import (name)", () =>
+  it("don't warn with bare import (cjs)", () =>
     withDir(`
       - entry.js: |
-          import "./foo.js";
+          require("./foo");
+      - foo.js: |
+          module.exports = "foo";
+    `, async resolve => {
+      let warns;
+      ({warns} = await bundle(resolve("entry.js"), {cache: resolve(".cjsescache")}));
+      assert.equal(warns.length, 0);
+    })
+  );
+  
+  it("don't warn with bare import (cjs + name)", () =>
+    withDir(`
+      - entry.js: |
+          require("./foo");
       - foo.js: |
           exports.foo = "foo";
     `, async resolve => {


### PR DESCRIPTION
Fixes #10.

I think this is fixed in #13. This PR only adds some tests.